### PR TITLE
Create operand function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project-specific files
+ignored/
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## NEXT
+
+## v0.1.0
+
+- Hello world!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+## v0.2.0
+
 - Create `symbolic.operand` function
 
 ## v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+- Create `symbolic.operand` function
+
 ## v0.1.0
 
 - Hello world!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symbolic"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/src/symbolic/__init__.py
+++ b/src/symbolic/__init__.py
@@ -4,20 +4,26 @@ Support for working with symbolic algebraic terms and expressions.
 
 import typing
 
-from ._definitions import (
+from ._expressions import (
     Expression,
+    expression_factory as expression,
+    reduce,
+)
+from ._helpers import (
+    standard,
+)
+from ._parsing import (
+    ParsingValueError,
+    ProductError,
+    RatioError,
+)
+from ._parts import (
     Operand,
     OperandFactory,
     OperandTypeError,
     OperandValueError,
-    ParsingValueError,
-    ProductError,
-    RatioError,
     Term,
     asterms,
-    expression_factory as expression,
-    reduce,
-    standard,
     term_factory as term,
 )
 

--- a/src/symbolic/__init__.py
+++ b/src/symbolic/__init__.py
@@ -24,6 +24,7 @@ from ._parts import (
     OperandValueError,
     Term,
     asterms,
+    create_operand as operand,
     term_factory as term,
 )
 
@@ -40,6 +41,7 @@ __all__ = [
     'RatioError',
     'Term',
     'asterms',
+    'operand',
     'expression',
     'reduce',
     'standard',

--- a/src/symbolic/__init__.py
+++ b/src/symbolic/__init__.py
@@ -6,6 +6,7 @@ import typing
 
 from ._definitions import (
     Expression,
+    Operand,
     OperandFactory,
     OperandTypeError,
     OperandValueError,
@@ -24,6 +25,7 @@ from ._definitions import (
 __all__ = [
     'Expression',
     'Expressable',
+    'Operand',
     'OperandFactory',
     'OperandTypeError',
     'OperandValueError',

--- a/src/symbolic/_expressions.py
+++ b/src/symbolic/_expressions.py
@@ -1,0 +1,415 @@
+import collections
+import collections.abc
+import fractions
+import functools
+import numbers
+from operator import attrgetter
+import typing
+
+from ._helpers import (
+    standard,
+)
+from ._parsing import (
+    Parser,
+)
+from ._parts import (
+    Term,
+    term_factory,
+)
+
+class Expression(collections.abc.Sequence):
+    """An object representing a symbolic expression."""
+
+    def __init__(self, terms: list[Term]) -> None:
+        self._terms = terms
+
+    def __bool__(self) -> bool:
+        """True if this expression is not empty."""
+        return not self.isempty
+
+    @property
+    def isempty(self):
+        """True if this expression contains no terms."""
+        return not self.terms
+
+    def __iter__(self) -> typing.Iterator[Term]:
+        return iter(self.terms)
+
+    def __len__(self) -> int:
+        return len(self.terms)
+
+    @typing.overload
+    def __getitem__(self, index: typing.SupportsIndex) -> Term: ...
+
+    @typing.overload
+    def __getitem__(self, index: slice) -> typing.Iterable[Term]: ...
+
+    def __getitem__(self, index):
+        """Access terms via standard indexing."""
+        if isinstance(index, typing.SupportsIndex):
+            idx = int(index)
+            if idx > len(self):
+                raise IndexError(index)
+            if idx < 0:
+                idx += len(self)
+            return self.terms[idx]
+        if isinstance(index, slice):
+            return self.terms[index]
+        raise IndexError(
+            f"Invalid index for expression: {index}"
+        ) from None
+
+    def __str__(self) -> str:
+        """A simplified representation of this instance."""
+        return self.format()
+
+    def __repr__(self):
+        """An unambiguous representation of this object."""
+        return f"{self.__class__.__qualname__}({self})"
+
+    def format(self, style: str=None, *, separator: str=' '):
+        """Join symbolic terms into a string.
+
+        Parameters
+        ----------
+        style : string, optional
+            The style in which to format each term. See `~Operand.format` for
+            available styles.
+
+        separator : string, default=' '
+            The string to place between terms.
+        """
+        formatted = (term.format(style=style) for term in self)
+        return separator.join(formatted)
+
+    def difference(self, other, symmetric: bool=False, split: bool=False):
+        """Compute the difference between two expressions.
+        
+        Parameters
+        ----------
+        other
+            The object with respect to which to compute the difference. If
+            `other` is not a `~symbolic.Expression`, this method will convert it
+            to one before proceeding.
+
+        symmetric : bool, default=False
+            If true, compute the symmetric difference between this expression
+            and `other`.
+
+        split : bool, default=False
+            If true, return the one-sided differences in a `list`. The first
+            element contains the terms in this expression that are not in
+            `other`, and the second element contains the terms in `other` that
+            are not in this expression.
+
+        Notes
+        -----
+        The `split` keyword argument takes precedence over the `symmetric`
+        keyword argument because the result of the former contains more
+        imformation than the result of the latter. See Examples for a suggestion
+        on converting a split result into a symmetric result.
+
+        Examples
+        --------
+        Consider the following two expressions:
+        
+        >>> e0 = symbolic.expression('a * b')
+        >>> e1 = symbolic.expression('a * c')
+
+        Their formal (one-sided) difference is
+
+        >>> e0.difference(e1)
+        {symbolic.term(b)}
+
+        Their formal symmetric difference is
+
+        >>> e0.difference(e1, symmetric=True)
+        {symbolic.term(b), symbolic.term(c)}
+
+        Passing `split=True` produces a `list` of `set`s
+
+        >>> e0.difference(e1, split=True)
+        [{symbolic.term(b)}, {symbolic.term(c)}]
+
+        To convert a split result into a symmetric result, simply compute the
+        union of the former:
+
+        >>> symmetric = e0.difference(e1, symmetric=True)
+        >>> split = e0.difference(e1, split=True)
+        >>> set.union(*split) == symmetric
+        True
+        """
+        if not isinstance(other, Expression):
+            other = expression_factory(other)
+        s0 = set(self.terms)
+        s1 = set(other.terms)
+        if split:
+            return [s0 - s1, s1 - s0]
+        if symmetric:
+            return s0 ^ s1
+        return s0 - s1
+
+    def __hash__(self):
+        """Compute hash(self)."""
+        return hash(tuple(self.terms))
+
+    @property
+    def terms(self):
+        """The symbolic terms in this expression."""
+        return self._terms
+
+    def __eq__(self, other) -> bool:
+        """True if two expressions have the same symbolic terms.
+
+        This method defines two expressions as equal if they have equivalent
+        lists of symbolic terms (a.k.a simple parts), regardless of order, after
+        parsing. Two expressions with different numbers of terms are always
+        false. If the expressions have the same number of terms, this method
+        will sort the triples (first by base, then by exponent, and finally by
+        coefficient) and compare the sorted lists. Two expressions are equal if
+        and only if their sorted lists of terms are equal.
+
+        If `other` is not an instance of this class, this method will first
+        attempt to convert it.
+        """
+        if not isinstance(other, Expression):
+            other = expression_factory(other)
+        if len(self) != len(other):
+            return False
+        key = attrgetter('base', 'exponent', 'coefficient')
+        return sorted(self, key=key) == sorted(other, key=key)
+
+    def __mul__(self, other):
+        """Called for self * other.
+
+        This method implements multiplication between two expressions by
+        reducing the exponents of terms with a common base. If `other` is a
+        string, it will first attempt to convert it to an `Expression`.
+        """
+        that = other if isinstance(other, Expression) else expression_factory(other)
+        if not that:
+            return NotImplemented
+        reduced = reduce(self, that)
+        return expression_factory(reduced)
+
+    def __rmul__(self, other: typing.Any):
+        """Called for other * self."""
+        return expression_factory(other).__mul__(self)
+
+    def __truediv__(self, other):
+        """Called for self / other.
+
+        This method implements division between two expressions by raising all
+        terms in `other` to -1, then reducing the exponents of terms with a
+        common base. If `other` is a string, it will first attempt to convert it
+        to an `Expression`.
+        """
+        that = other if isinstance(other, Expression) else expression_factory(other)
+        if not that:
+            return NotImplemented
+        return expression_factory(reduce(self, [term ** -1 for term in that]))
+
+    def __rtruediv__(self, other: typing.Any):
+        """Called for other / self."""
+        return expression_factory(other).__truediv__(self)
+
+    def __pow__(self, exp: numbers.Real):
+        """Called for self ** exp.
+
+        This method implements exponentiation of an expression by raising all
+        terms to the given power, then reducing exponents of terms with a common
+        base. It will first attempt to convert `exp` to a float.
+        """
+        exp = float(exp)
+        if not exp:
+            return NotImplemented
+        terms = [pow(term, exp) for term in self]
+        return expression_factory(reduce(terms))
+
+    def apply(self, update: typing.Callable):
+        """Create a new expression by applying the given callable object.
+        
+        Parameters
+        ----------
+        update : callable
+            The callable object that this method should use to update the base
+            of each term in this expression.
+
+        Returns
+        -------
+        `~symbolic.Expression`
+        """
+        bases = [update(term.base) for term in self]
+        exponents = [term.exponent for term in self]
+        result = bases[0] ** exponents[0]
+        for base, exponent in zip(bases[1:], exponents[1:]):
+            result *= base ** exponent
+        return result
+
+
+S = typing.TypeVar('S', str, numbers.Number)
+
+
+@typing.overload
+def expression_factory(*args, **kwargs) -> Expression:
+    """Create an expression from the given arguments, if possible."""
+
+@typing.overload
+def expression_factory(expression: S, /, **kwargs) -> Expression:
+    """Create an expression from a single value.
+
+    Parameters
+    ----------
+    expression : string or number
+        The value to convert into an expression.
+
+    **kwargs
+        Keywords to pass to `~symbolic.Parser`.
+
+    Examples
+    --------
+    Create a symbolic expression from a string that represents the result of
+    multiplying `a^3/2` by `b`, dividing by `c^1/2`, and squaring the ratio:
+
+    >>> symbolic.expression('(a^3/2 * b / c^1/2)^2')
+    symbolic.Expression(a^3 b^2 c^-1)
+    """
+
+@typing.overload
+def expression_factory(
+    expression: typing.Iterable[S],
+    /,
+    **kwargs,
+) -> Expression:
+    """Create an expression from an iterable of values.
+
+    Parameters
+    ----------
+    expression : iterable of strings or numbers
+        The iterable object with which to initialize the new instance. All
+        members must support conversion to a string in the form of a
+        `~symbolic.Term`.
+
+    **kwargs
+        Keywords to pass to `~symbolic.Parser`.
+
+    Examples
+    --------
+    Create a symbolic expression from a list of the individual string terms in
+    the result of multiplying `a^3/2` by `b`, dividing by `c^1/2`, and squaring
+    the ratio:
+
+    >>> symbolic.expression(['a^3', 'b', 'c^-1'])
+    symbolic.Expression(a^3 b c^-1)
+    """
+
+@typing.overload
+def expression_factory(expression: Expression, /) -> Expression:
+    """Create an expression from an expression.
+
+    This mode exists to support algorithms that don't know the type of argument
+    until runtime. If the type is known, it is simpler to use the existing
+    instance.
+
+    Parameters
+    ----------
+    expression : `~symbolic.Expression`
+        An existing instance of this class.
+
+    Examples
+    --------
+    Create an instance from a string:
+
+    >>> this = symbolic.expression('a * b / c')
+
+    Pass the first instance to this class:
+
+    >>> that = symbolic.expression(this)
+
+    Both `this` and `that` represent the same expression...
+
+    >>> this
+    symbolic.expression(a b c^-1)
+    >>> that
+    symbolic.expression(a b c^-1)
+
+    ...because they are the same object.
+
+    >>> that is this
+    True
+    """
+
+def expression_factory(this, **options):
+    if isinstance(this, Expression):
+        if not options:
+            return this
+        raise ValueError(
+            f"Cannot update parsing options on an existing expression"
+        ) from None
+    string = standard(this, joiner='*')
+    terms = _init_terms(string, Parser(**options))
+    return Expression(terms)
+
+
+def _init_terms(
+    string: str,
+    parser: Parser,
+) -> list[Term]:
+    """Initialize terms for an expression by parsing `string`."""
+    if string is None:
+        return []
+    terms = parser.parse(string)
+    return reduce(terms)
+
+
+def reduce(*groups: typing.Iterable[Term]):
+    """Algebraically reduce terms with equal bases.
+
+    Parameters
+    ----------
+    *groups : tuple of iterables
+        One or more iterables of `~symbolic.Term` instances. If there are
+        multiple groups, this method will combine all terms it finds in the full
+        collection of groups.
+
+    Notes
+    -----
+    This function will sort terms in order of ascending exponent, and
+    alphabetically for equal exponents.
+    """
+    terms = [t for group in groups for t in group]
+    reduced = {}
+    for t in terms:
+        if t.base in reduced:
+            reduced[t.base]['coefficient'] *= t.coefficient
+            reduced[t.base]['exponent'] += t.exponent
+        else:
+            attributes = {
+                'coefficient': t.coefficient,
+                'exponent': t.exponent,
+            }
+            reduced[t.base] = attributes
+    fracs = [
+        fractions.Fraction(v['coefficient'])
+        for v in reduced.values()
+    ]
+    tmp = [
+        term_factory(base=k, exponent=v['exponent'])
+        for k, v in reduced.items()
+        if k != '1' and v['exponent'] != 0
+    ]
+    # Sort: high to low in exponent, followed by alphabetic in base.
+    variables = sorted(
+        sorted(tmp, key=attrgetter('base')),
+        key=attrgetter('exponent'),
+        reverse=True,
+    )
+    c = functools.reduce(lambda x, y: x*y, fracs)
+    constant = [term_factory(coefficient=c)]
+    if not variables:
+        return constant
+    if c == 1:
+        return variables
+    return constant + variables
+
+

--- a/src/symbolic/_helpers.py
+++ b/src/symbolic/_helpers.py
@@ -1,0 +1,60 @@
+import numbers
+import typing
+
+
+def standard(
+    this,
+    missing: str | None = None,
+    joiner: str='*',
+) -> str:
+    """Convert `this` to a standard format.
+    
+    Parameters
+    ----------
+    this : string or iterable
+        The object to convert.
+
+    missing : string, optional
+        The value to return if `this` is null.
+
+    joiner : string, default='*'
+        The string token to use when joining parts of an iterable argument.
+
+    See Also
+    --------
+    `~symbolic.Expression`: A class that represents one or more terms joined by
+    symbolic operators and grouped by separator characters. Instances support
+    multiplication and division with strings or other instances, and
+    exponentiation by real numbers. Instantiation automatically calls this
+    function.
+    """
+    if isnull(this):
+        return missing
+    if isinstance(this, str):
+        return this
+    try:
+        iter(this)
+    except TypeError:
+        return str(this)
+    else:
+        return joiner.join(f"({part})" for part in this)
+
+
+def isnull(this: typing.Any) -> bool:
+    """True if `this` is empty but not if it's 0.
+
+    This function allows the calling code to programmatically test for objects
+    that are logically `False` except for numbers equivalent to 0.
+    """
+    if isinstance(this, numbers.Number):
+        return False
+    size = getattr(this, 'size', None)
+    if size is not None:
+        return size == 0
+    try:
+        result = not bool(this)
+    except ValueError:
+        result = all((isnull(i) for i in this))
+    return result
+
+

--- a/src/symbolic/_parsing.py
+++ b/src/symbolic/_parsing.py
@@ -1,0 +1,257 @@
+import typing
+
+from ._parts import (
+    Operand,
+    OperandFactory,
+    Operator,
+    OperatorFactory,
+    Term,
+    term_factory,
+)
+
+class ParsingError(Exception):
+    """Base class for exceptions encountered during symbolic parsing."""
+
+    def __init__(self, arg: typing.Any) -> None:
+        self.arg = arg
+
+
+class RatioError(ParsingError):
+    """The string contains multiple '/' on a single level."""
+
+    def __str__(self) -> str:
+        return (
+            f"The expression '{self.arg}' contains ambiguous '/'."
+            f" Please refer to the NIST guidelines"
+            f" (https://physics.nist.gov/cuu/Units/checklist.html)"
+            f" for more information."
+        )
+
+
+class ProductError(ParsingError):
+    """The string contains a '*' after a '/'."""
+
+    def __str__(self) -> str:
+        return (
+            f"The expression '{self.arg}' contains an ambiguous '*'."
+            f" Please group '*' in parentheses when following '/'."
+        )
+
+
+class ParsingValueError(ValueError):
+    """Cannot create an expression from the given string."""
+    pass
+
+
+class Iteration:
+    """An object that keeps track of parsing attributes."""
+
+    __slots__ = ('string', 'operator', 'operand')
+
+    def __init__(
+        self,
+        string: str,
+        operator: Operator=None,
+        operand: Operand=None,
+    ) -> None:
+        self.string = string
+        self.operator = operator
+        self.operand = operand
+
+    @property
+    def _attrs(self):
+        """Internal mapping of current attribute values."""
+        return {name: getattr(self, name) for name in self.__slots__}
+
+    def copy(self):
+        """Make a copy of this instance."""
+        return type(self)(**self._attrs)
+
+    def __str__(self):
+        """A simplified representation of this object."""
+        return ', '.join(f"{k}={v!r}" for k, v in self._attrs.items())
+
+    def __repr__(self):
+        """An unambiguous representation of this object."""
+        return f"{self.__class__.__qualname__}({self})"
+
+
+class Parser:
+    """A tool for parsing symbolic expressions."""
+
+    def __init__(
+        self,
+        multiply: str='*',
+        divide: str='/',
+        opening: str='(',
+        closing: str=')',
+        raising: str='^',
+        operator_order: str='ignore',
+    ) -> None:
+        """
+        Initialize a parser with fixed tokens.
+
+        Parameters
+        ----------
+        multiply : string, default='*'
+            The token that represents multiplication.
+
+        divide : string, default='/'
+            The token that represents division.
+
+        opening : string, default='('
+            The token that represents an opening separator.
+
+        closing : string, default='('
+            The token that represents a closing separator.
+
+        raising : string, default='^'
+            The token that represents raising to a power (exponentiation).
+
+        operator_order : {'ignore', 'error'}
+            Determines how the parser responds when operator order violates NIST
+            guidelines. If set to `'ignore'` (default), it will treat operators
+            independent of one another. If set to `'error'`, the parser will
+            raise an exception based on the type of violation.
+        """
+        self.operands = OperandFactory(opening, closing, raising)
+        self.operators = OperatorFactory(multiply, divide)
+        self.parsers = (self.operands, self.operators)
+        self.tokens = {
+            'multiply': multiply,
+            'divide': divide,
+            'opening': opening,
+            'closing': closing,
+            'raising': raising,
+        }
+        self._operator_order = operator_order
+
+    def parse(self, string: str):
+        """Resolve the given string into individual terms."""
+        operand = Operand(base=string)
+        return self._resolve_operations(operand)
+
+    def _resolve_operations(
+        self,
+        current: Operand,
+    ) -> list[Term]:
+        """Separate a symbolic group into operators and operands."""
+        operands = self._parse_operand(current)
+        return [
+            t for operand in operands
+            for t in self._update_terms(operand)
+        ] + [term_factory(coefficient=current.coefficient)]
+
+    def _parse_operand(
+        self,
+        initial: Operand,
+    ) -> list[Operand]:
+        """Resolve a general operand into simpler operands.
+
+        This method parses known operators and operands from the initial operand
+        while preserving nested groups in the latter. Calling code may then pass
+        those nested groups back in for further parsing.
+        """
+        operands = []
+        current = Iteration(initial.base)
+        previous = current.copy()
+        while current.string:
+            current = self._get_operator(initial, current, previous)
+            current = self._get_operand(initial, current)
+            if new := self._compute_operand(current):
+                operands.append(new)
+            previous = current.copy()
+            current = Iteration(previous.string)
+        return operands
+
+    def _get_operator(
+        self,
+        initial: Operand,
+        current: Iteration,
+        previous: Iteration,
+    ) -> Iteration:
+        """Attempt to parse an operator from the current string."""
+        if parsed := self.operators.parse(current.string):
+            current.operator = parsed.result
+            if exception := self._operator_error(
+                    current.operator,
+                    previous.operator,
+                ): raise exception(initial)
+            current.string = parsed.remainder
+        return current
+
+    def _get_operand(
+        self,
+        initial: Operand,
+        current: Iteration,
+    ) -> Iteration:
+        """Attempt to parse an operand from the current string."""
+        if parsed := self.operands.parse(current.string):
+            current.operand = parsed.result ** initial.exponent
+            current.string = parsed.remainder
+        return current
+
+    def _compute_operand(self, current: Iteration):
+        """Create a new operand from the current iteration."""
+        if current.operand and current.operator:
+            return self._evaluate(current.operator, current.operand)
+        if current.operand:
+            return current.operand
+        if current.operator:
+            raise ParsingValueError("Operator without operand")
+        raise ParsingValueError("Failed to parse string")
+
+    def _operator_error(
+        self,
+        current: Operator,
+        previous: Operator,
+    ) -> type[ParsingError] | None:
+        """Check for known operator-related errors.
+        
+        This method checks for the following errors and returns the appropriate
+        exception class if it finds one:
+
+        - Multiple divisions on a single level (e.g., `'a / b / c'`), which
+          results in a `RatioError`.
+
+        - Multiplication after division on the same level (e.g., `'a / b * c'`),
+          which results in a `ProductError`.
+
+        Both of the examples shown above result in errors because they each
+        introduce an ambiguous order of operations. Users can resolve the
+        ambiguity by properly grouping terms in the expression. Continuing with
+        the above examples, `'a / b / c'` should become `'(a / b) / c'` or `'a /
+        (b / c)'`, and `'a / b * c'` should become `'(a / b) * c'` or `'a / (b *
+        c)'`.
+        """
+        if self._operator_order == 'ignore':
+            return
+        if previous == 'divide':
+            if current == 'divide':
+                return RatioError
+            if current == 'multiply':
+                return ProductError
+
+    def _evaluate(
+        self,
+        operator: Operator,
+        operand: Operand,
+    ) -> Operand:
+        """Compute the effect of `operator` on `operand`."""
+        if operator in {'multiply', 'identity'}:
+            return operand
+        if operator == 'divide':
+            return operand ** -1
+        if operator == 'sqrt':
+            return operand ** 0.5
+        raise ValueError(f"Unrecognized operator {operator!r}")
+
+    def _update_terms(self, operand: Operand):
+        """Store a new term or initiate further parsing."""
+        # TODO: Consider extracting all coefficients, at least as separate
+        # constant terms.
+        if isinstance(operand, Term):
+            return [operand]
+        return self._resolve_operations(operand)
+
+

--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -436,7 +436,13 @@ class OperandFactory(Factory):
             fill=True,
         )
 
-    def create(self, *args, strict: bool=False) -> Operand | None:
+    @typing.overload
+    def create(self, *args, strict: bool = False) -> Operand: ...
+
+    @typing.overload
+    def create(self, *args, strict: bool = ...) -> Operand | None: ...
+
+    def create(self, *args, strict=False):
         """Create an operand from input.
 
         Parameters
@@ -802,6 +808,32 @@ class OperandFactory(Factory):
         string = self.patterns['opening'].sub('', string, count=1)
         string = self.patterns['closing'].sub('', string[::-1], count=1)
         return string[::-1]
+
+
+@typing.overload
+def create_operand(
+    *args,
+    strict: bool = False,
+    opening: str = ...,
+    closing: str = ...,
+    raising: str = ...,
+) -> Operand: ...
+
+@typing.overload
+def create_operand(
+    *args,
+    strict: bool = ...,
+    opening: str = ...,
+    closing: str = ...,
+    raising: str = ...,
+    ) -> Operand | None: ...
+
+def create_operand(*args, strict=False, **kwargs):
+    """Create an operand object.
+    
+    This is a convenience function for `~OperandFactory.create`.
+    """
+    return OperandFactory(**kwargs).create(*args, strict=strict)
 
 
 class Term(Operand):

--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -1,11 +1,7 @@
 import abc
-import collections
-import collections.abc
 import fractions
-import functools
 import itertools
 import numbers
-from operator import attrgetter
 import re
 import typing
 
@@ -39,7 +35,7 @@ class Match(typing.Generic[_PartType]):
     def __init__(
         self,
         result: _PartType,
-        context: typing.Union[re.Match, typing.Mapping],
+        context: re.Match | typing.Mapping,
     ) -> None:
         self.result = result
         """The result of the match attempt."""
@@ -102,18 +98,6 @@ class Match(typing.Generic[_PartType]):
         return ', '.join(f"{k}: {getattr(self, v)}" for k, v in attrs.items())
 
 
-class Factory(typing.Protocol):
-    """Abstract protocol class for symbolic factories."""
-
-    @abc.abstractmethod
-    def parse(self) -> Match: ...
-
-
-@typing.runtime_checkable
-class FactoryType(Factory, typing.Protocol):
-    """Runtime protocol for symbolic factories."""
-
-
 class Operator(Part):
     """An operator in a symbolic expression."""
 
@@ -135,40 +119,6 @@ class Operator(Part):
         if isinstance(other, str):
             return other == self.operation
         return NotImplemented
-
-
-class OperatorFactory(Factory):
-    """A factory that produces symbolic operators."""
-
-    def __init__(
-        self,
-        multiply: str='*',
-        divide: str='/',
-    ) -> None:
-        mul = fr'\{multiply}'
-        div = fr'\{divide}'
-        self.patterns = {
-            'multiply': re.compile(
-                fr'(?<!{div})(\s*{mul}\s*)(?!{div})'
-            ),
-            'divide': re.compile(
-                fr'(?<!{mul})(\s*{div}\s*)(?!{mul})'
-            ),
-            'sqrt': re.compile(r'\s*sqrt\s*')
-        }
-        """Compiled regular expressions for symbolic operators."""
-
-    def parse(self, string: str):
-        """Extract an operator at the start of `string`, possible."""
-        for key in self.patterns:
-            if match := self.patterns[key].match(string):
-                return Match(
-                    result=Operator(key),
-                    context=match,
-                )
-
-
-T = typing.TypeVar('T')
 
 
 class OperandTypeError(TypeError):
@@ -284,6 +234,63 @@ class Operand(Part):
         if self.coefficient != 1:
             string = f"{self.coefficient}{string}"
         return string
+
+
+T = typing.TypeVar('T')
+
+
+def apply(
+    methods: typing.Iterable[typing.Callable[..., T]],
+    *args,
+    **kwargs,
+) -> T | None:
+    """Apply the given methods until one returns a non-null result."""
+    gen = (method(*args, **kwargs) for method in methods)
+    if result := next((match for match in gen if match), None):
+        return result
+
+
+class Factory(typing.Protocol):
+    """Abstract protocol class for symbolic factories."""
+
+    @abc.abstractmethod
+    def parse(self) -> Match: ...
+
+
+@typing.runtime_checkable
+class FactoryType(Factory, typing.Protocol):
+    """Runtime protocol for symbolic factories."""
+
+
+class OperatorFactory(Factory):
+    """A factory that produces symbolic operators."""
+
+    def __init__(
+        self,
+        multiply: str='*',
+        divide: str='/',
+    ) -> None:
+        mul = fr'\{multiply}'
+        div = fr'\{divide}'
+        self.patterns = {
+            'multiply': re.compile(
+                fr'(?<!{div})(\s*{mul}\s*)(?!{div})'
+            ),
+            'divide': re.compile(
+                fr'(?<!{mul})(\s*{div}\s*)(?!{mul})'
+            ),
+            'sqrt': re.compile(r'\s*sqrt\s*')
+        }
+        """Compiled regular expressions for symbolic operators."""
+
+    def parse(self, string: str):
+        """Extract an operator at the start of `string`, possible."""
+        for key in self.patterns:
+            if match := self.patterns[key].match(string):
+                return Match(
+                    result=Operator(key),
+                    context=match,
+                )
 
 
 class OperandFactory(Factory):
@@ -429,7 +436,7 @@ class OperandFactory(Factory):
             fill=True,
         )
 
-    def create(self, *args, strict: bool=False) -> typing.Optional[Operand]:
+    def create(self, *args, strict: bool=False) -> Operand | None:
         """Create an operand from input.
 
         Parameters
@@ -568,7 +575,7 @@ class OperandFactory(Factory):
         string: str,
         mode: str='match',
         start: int=0,
-    ) -> typing.Optional[Match[Operand]]:
+    ) -> Match[Operand] | None:
         """Attempt to find an irreducible term at the start of `string`.
 
         Notes
@@ -630,7 +637,7 @@ class OperandFactory(Factory):
         string: str,
         mode: str='match',
         start: int=0,
-    ) -> typing.Optional[Match[Operand]]:
+    ) -> Match[Operand] | None:
         """Attempt to match a complex operand at the start of `string`."""
         target = string[start:]
         bounds = self.find_bounds(target)
@@ -736,7 +743,7 @@ class OperandFactory(Factory):
         self,
         fill: bool=False,
         **given
-    ) -> typing.Dict[str, typing.Union[float, int, str, fractions.Fraction]]:
+    ) -> dict[str, float | int | str | fractions.Fraction]:
         """Cast to appropriate types and fill in defaults, if necessary."""
         full = {
             'coefficient': {'callable': self._standard_coefficient},
@@ -795,17 +802,6 @@ class OperandFactory(Factory):
         string = self.patterns['opening'].sub('', string, count=1)
         string = self.patterns['closing'].sub('', string[::-1], count=1)
         return string[::-1]
-
-
-def apply(
-    methods: typing.Iterable[typing.Callable[..., T]],
-    *args,
-    **kwargs,
-) -> typing.Optional[T]:
-    """Apply the given methods until one returns a non-null result."""
-    gen = (method(*args, **kwargs) for method in methods)
-    if result := next((match for match in gen if match), None):
-        return result
 
 
 class Term(Operand):
@@ -1030,703 +1026,5 @@ def _validate_term_base(base):
 def asterms(these: typing.Iterable[str]):
     """Convert strings to terms, if possible."""
     return [OperandFactory().create(this) for this in these]
-
-
-class ParsingError(Exception):
-    """Base class for exceptions encountered during symbolic parsing."""
-
-    def __init__(self, arg: typing.Any) -> None:
-        self.arg = arg
-
-
-class RatioError(ParsingError):
-    """The string contains multiple '/' on a single level."""
-
-    def __str__(self) -> str:
-        return (
-            f"The expression '{self.arg}' contains ambiguous '/'."
-            f" Please refer to the NIST guidelines"
-            f" (https://physics.nist.gov/cuu/Units/checklist.html)"
-            f" for more information."
-        )
-
-
-class ProductError(ParsingError):
-    """The string contains a '*' after a '/'."""
-
-    def __str__(self) -> str:
-        return (
-            f"The expression '{self.arg}' contains an ambiguous '*'."
-            f" Please group '*' in parentheses when following '/'."
-        )
-
-
-class ParsingValueError(ValueError):
-    """Cannot create an expression from the given string."""
-    pass
-
-
-class Iteration:
-    """An object that keeps track of parsing attributes."""
-
-    __slots__ = ('string', 'operator', 'operand')
-
-    def __init__(
-        self,
-        string: str,
-        operator: Operator=None,
-        operand: Operand=None,
-    ) -> None:
-        self.string = string
-        self.operator = operator
-        self.operand = operand
-
-    @property
-    def _attrs(self):
-        """Internal mapping of current attribute values."""
-        return {name: getattr(self, name) for name in self.__slots__}
-
-    def copy(self):
-        """Make a copy of this instance."""
-        return type(self)(**self._attrs)
-
-    def __str__(self):
-        """A simplified representation of this object."""
-        return ', '.join(f"{k}={v!r}" for k, v in self._attrs.items())
-
-    def __repr__(self):
-        """An unambiguous representation of this object."""
-        return f"{self.__class__.__qualname__}({self})"
-
-
-class Parser:
-    """A tool for parsing symbolic expressions."""
-
-    def __init__(
-        self,
-        multiply: str='*',
-        divide: str='/',
-        opening: str='(',
-        closing: str=')',
-        raising: str='^',
-        operator_order: str='ignore',
-    ) -> None:
-        """
-        Initialize a parser with fixed tokens.
-
-        Parameters
-        ----------
-        multiply : string, default='*'
-            The token that represents multiplication.
-
-        divide : string, default='/'
-            The token that represents division.
-
-        opening : string, default='('
-            The token that represents an opening separator.
-
-        closing : string, default='('
-            The token that represents a closing separator.
-
-        raising : string, default='^'
-            The token that represents raising to a power (exponentiation).
-
-        operator_order : {'ignore', 'error'}
-            Determines how the parser responds when operator order violates NIST
-            guidelines. If set to `'ignore'` (default), it will treat operators
-            independent of one another. If set to `'error'`, the parser will
-            raise an exception based on the type of violation.
-        """
-        self.operands = OperandFactory(opening, closing, raising)
-        self.operators = OperatorFactory(multiply, divide)
-        self.parsers = (self.operands, self.operators)
-        self.tokens = {
-            'multiply': multiply,
-            'divide': divide,
-            'opening': opening,
-            'closing': closing,
-            'raising': raising,
-        }
-        self._operator_order = operator_order
-
-    def parse(self, string: str):
-        """Resolve the given string into individual terms."""
-        operand = Operand(base=string)
-        return self._resolve_operations(operand)
-
-    def _resolve_operations(
-        self,
-        current: Operand,
-    ) -> typing.List[Term]:
-        """Separate a symbolic group into operators and operands."""
-        operands = self._parse_operand(current)
-        return [
-            t for operand in operands
-            for t in self._update_terms(operand)
-        ] + [term_factory(coefficient=current.coefficient)]
-
-    def _parse_operand(
-        self,
-        initial: Operand,
-    ) -> typing.List[Operand]:
-        """Resolve a general operand into simpler operands.
-
-        This method parses known operators and operands from the initial operand
-        while preserving nested groups in the latter. Calling code may then pass
-        those nested groups back in for further parsing.
-        """
-        operands = []
-        current = Iteration(initial.base)
-        previous = current.copy()
-        while current.string:
-            current = self._get_operator(initial, current, previous)
-            current = self._get_operand(initial, current)
-            if new := self._compute_operand(current):
-                operands.append(new)
-            previous = current.copy()
-            current = Iteration(previous.string)
-        return operands
-
-    def _get_operator(
-        self,
-        initial: Operand,
-        current: Iteration,
-        previous: Iteration,
-    ) -> Iteration:
-        """Attempt to parse an operator from the current string."""
-        if parsed := self.operators.parse(current.string):
-            current.operator = parsed.result
-            if exception := self._operator_error(
-                    current.operator,
-                    previous.operator,
-                ): raise exception(initial)
-            current.string = parsed.remainder
-        return current
-
-    def _get_operand(
-        self,
-        initial: Operand,
-        current: Iteration,
-    ) -> Iteration:
-        """Attempt to parse an operand from the current string."""
-        if parsed := self.operands.parse(current.string):
-            current.operand = parsed.result ** initial.exponent
-            current.string = parsed.remainder
-        return current
-
-    def _compute_operand(self, current: Iteration):
-        """Create a new operand from the current iteration."""
-        if current.operand and current.operator:
-            return self._evaluate(current.operator, current.operand)
-        if current.operand:
-            return current.operand
-        if current.operator:
-            raise ParsingValueError("Operator without operand")
-        raise ParsingValueError("Failed to parse string")
-
-    def _operator_error(
-        self,
-        current: Operator,
-        previous: Operator,
-    ) -> typing.Optional[typing.Type[ParsingError]]:
-        """Check for known operator-related errors.
-        
-        This method checks for the following errors and returns the appropriate
-        exception class if it finds one:
-
-        - Multiple divisions on a single level (e.g., `'a / b / c'`), which
-          results in a `RatioError`.
-
-        - Multiplication after division on the same level (e.g., `'a / b * c'`),
-          which results in a `ProductError`.
-
-        Both of the examples shown above result in errors because they each
-        introduce an ambiguous order of operations. Users can resolve the
-        ambiguity by properly grouping terms in the expression. Continuing with
-        the above examples, `'a / b / c'` should become `'(a / b) / c'` or `'a /
-        (b / c)'`, and `'a / b * c'` should become `'(a / b) * c'` or `'a / (b *
-        c)'`.
-        """
-        if self._operator_order == 'ignore':
-            return
-        if previous == 'divide':
-            if current == 'divide':
-                return RatioError
-            if current == 'multiply':
-                return ProductError
-
-    def _evaluate(
-        self,
-        operator: Operator,
-        operand: Operand,
-    ) -> Operand:
-        """Compute the effect of `operator` on `operand`."""
-        if operator in {'multiply', 'identity'}:
-            return operand
-        if operator == 'divide':
-            return operand ** -1
-        if operator == 'sqrt':
-            return operand ** 0.5
-        raise ValueError(f"Unrecognized operator {operator!r}")
-
-    def _update_terms(self, operand: Operand):
-        """Store a new term or initiate further parsing."""
-        # TODO: Consider extracting all coefficients, at least as separate
-        # constant terms.
-        if isinstance(operand, Term):
-            return [operand]
-        return self._resolve_operations(operand)
-
-
-S = typing.TypeVar('S', str, numbers.Number)
-
-
-class Expression(collections.abc.Sequence):
-    """An object representing a symbolic expression."""
-
-    def __init__(self, terms: typing.List[Term]) -> None:
-        self._terms = terms
-
-    def __bool__(self) -> bool:
-        """True if this expression is not empty."""
-        return not self.isempty
-
-    @property
-    def isempty(self):
-        """True if this expression contains no terms."""
-        return not self.terms
-
-    def __iter__(self) -> typing.Iterator[Term]:
-        return iter(self.terms)
-
-    def __len__(self) -> int:
-        return len(self.terms)
-
-    @typing.overload
-    def __getitem__(self, index: typing.SupportsIndex) -> Term: ...
-
-    @typing.overload
-    def __getitem__(self, index: slice) -> typing.Iterable[Term]: ...
-
-    def __getitem__(self, index):
-        """Access terms via standard indexing."""
-        if isinstance(index, typing.SupportsIndex):
-            idx = int(index)
-            if idx > len(self):
-                raise IndexError(index)
-            if idx < 0:
-                idx += len(self)
-            return self.terms[idx]
-        if isinstance(index, slice):
-            return self.terms[index]
-        raise IndexError(
-            f"Invalid index for expression: {index}"
-        ) from None
-
-    def __str__(self) -> str:
-        """A simplified representation of this instance."""
-        return self.format()
-
-    def __repr__(self):
-        """An unambiguous representation of this object."""
-        return f"{self.__class__.__qualname__}({self})"
-
-    def format(self, style: str=None, *, separator: str=' '):
-        """Join symbolic terms into a string.
-
-        Parameters
-        ----------
-        style : string, optional
-            The style in which to format each term. See `~Operand.format` for
-            available styles.
-
-        separator : string, default=' '
-            The string to place between terms.
-        """
-        formatted = (term.format(style=style) for term in self)
-        return separator.join(formatted)
-
-    def difference(self, other, symmetric: bool=False, split: bool=False):
-        """Compute the difference between two expressions.
-        
-        Parameters
-        ----------
-        other
-            The object with respect to which to compute the difference. If
-            `other` is not a `~symbolic.Expression`, this method will convert it
-            to one before proceeding.
-
-        symmetric : bool, default=False
-            If true, compute the symmetric difference between this expression
-            and `other`.
-
-        split : bool, default=False
-            If true, return the one-sided differences in a `list`. The first
-            element contains the terms in this expression that are not in
-            `other`, and the second element contains the terms in `other` that
-            are not in this expression.
-
-        Notes
-        -----
-        The `split` keyword argument takes precedence over the `symmetric`
-        keyword argument because the result of the former contains more
-        imformation than the result of the latter. See Examples for a suggestion
-        on converting a split result into a symmetric result.
-
-        Examples
-        --------
-        Consider the following two expressions:
-        
-        >>> e0 = symbolic.expression('a * b')
-        >>> e1 = symbolic.expression('a * c')
-
-        Their formal (one-sided) difference is
-
-        >>> e0.difference(e1)
-        {symbolic.term(b)}
-
-        Their formal symmetric difference is
-
-        >>> e0.difference(e1, symmetric=True)
-        {symbolic.term(b), symbolic.term(c)}
-
-        Passing `split=True` produces a `list` of `set`s
-
-        >>> e0.difference(e1, split=True)
-        [{symbolic.term(b)}, {symbolic.term(c)}]
-
-        To convert a split result into a symmetric result, simply compute the
-        union of the former:
-
-        >>> symmetric = e0.difference(e1, symmetric=True)
-        >>> split = e0.difference(e1, split=True)
-        >>> set.union(*split) == symmetric
-        True
-        """
-        if not isinstance(other, Expression):
-            other = expression_factory(other)
-        s0 = set(self.terms)
-        s1 = set(other.terms)
-        if split:
-            return [s0 - s1, s1 - s0]
-        if symmetric:
-            return s0 ^ s1
-        return s0 - s1
-
-    def __hash__(self):
-        """Compute hash(self)."""
-        return hash(tuple(self.terms))
-
-    @property
-    def terms(self):
-        """The symbolic terms in this expression."""
-        return self._terms
-
-    def __eq__(self, other) -> bool:
-        """True if two expressions have the same symbolic terms.
-
-        This method defines two expressions as equal if they have equivalent
-        lists of symbolic terms (a.k.a simple parts), regardless of order, after
-        parsing. Two expressions with different numbers of terms are always
-        false. If the expressions have the same number of terms, this method
-        will sort the triples (first by base, then by exponent, and finally by
-        coefficient) and compare the sorted lists. Two expressions are equal if
-        and only if their sorted lists of terms are equal.
-
-        If `other` is not an instance of this class, this method will first
-        attempt to convert it.
-        """
-        if not isinstance(other, Expression):
-            other = expression_factory(other)
-        if len(self) != len(other):
-            return False
-        key = attrgetter('base', 'exponent', 'coefficient')
-        return sorted(self, key=key) == sorted(other, key=key)
-
-    def __mul__(self, other):
-        """Called for self * other.
-
-        This method implements multiplication between two expressions by
-        reducing the exponents of terms with a common base. If `other` is a
-        string, it will first attempt to convert it to an `Expression`.
-        """
-        that = other if isinstance(other, Expression) else expression_factory(other)
-        if not that:
-            return NotImplemented
-        reduced = reduce(self, that)
-        return expression_factory(reduced)
-
-    def __rmul__(self, other: typing.Any):
-        """Called for other * self."""
-        return expression_factory(other).__mul__(self)
-
-    def __truediv__(self, other):
-        """Called for self / other.
-
-        This method implements division between two expressions by raising all
-        terms in `other` to -1, then reducing the exponents of terms with a
-        common base. If `other` is a string, it will first attempt to convert it
-        to an `Expression`.
-        """
-        that = other if isinstance(other, Expression) else expression_factory(other)
-        if not that:
-            return NotImplemented
-        return expression_factory(reduce(self, [term ** -1 for term in that]))
-
-    def __rtruediv__(self, other: typing.Any):
-        """Called for other / self."""
-        return expression_factory(other).__truediv__(self)
-
-    def __pow__(self, exp: numbers.Real):
-        """Called for self ** exp.
-
-        This method implements exponentiation of an expression by raising all
-        terms to the given power, then reducing exponents of terms with a common
-        base. It will first attempt to convert `exp` to a float.
-        """
-        exp = float(exp)
-        if not exp:
-            return NotImplemented
-        terms = [pow(term, exp) for term in self]
-        return expression_factory(reduce(terms))
-
-    def apply(self, update: typing.Callable):
-        """Create a new expression by applying the given callable object.
-        
-        Parameters
-        ----------
-        update : callable
-            The callable object that this method should use to update the base
-            of each term in this expression.
-
-        Returns
-        -------
-        `~symbolic.Expression`
-        """
-        bases = [update(term.base) for term in self]
-        exponents = [term.exponent for term in self]
-        result = bases[0] ** exponents[0]
-        for base, exponent in zip(bases[1:], exponents[1:]):
-            result *= base ** exponent
-        return result
-
-
-@typing.overload
-def expression_factory(*args, **kwargs) -> Expression:
-    """Create an expression from the given arguments, if possible."""
-
-@typing.overload
-def expression_factory(expression: S, /, **kwargs) -> Expression:
-    """Create an expression from a single value.
-
-    Parameters
-    ----------
-    expression : string or number
-        The value to convert into an expression.
-
-    **kwargs
-        Keywords to pass to `~symbolic.Parser`.
-
-    Examples
-    --------
-    Create a symbolic expression from a string that represents the result of
-    multiplying `a^3/2` by `b`, dividing by `c^1/2`, and squaring the ratio:
-
-    >>> symbolic.expression('(a^3/2 * b / c^1/2)^2')
-    symbolic.Expression(a^3 b^2 c^-1)
-    """
-
-@typing.overload
-def expression_factory(
-    expression: typing.Iterable[S],
-    /,
-    **kwargs,
-) -> Expression:
-    """Create an expression from an iterable of values.
-
-    Parameters
-    ----------
-    expression : iterable of strings or numbers
-        The iterable object with which to initialize the new instance. All
-        members must support conversion to a string in the form of a
-        `~symbolic.Term`.
-
-    **kwargs
-        Keywords to pass to `~symbolic.Parser`.
-
-    Examples
-    --------
-    Create a symbolic expression from a list of the individual string terms in
-    the result of multiplying `a^3/2` by `b`, dividing by `c^1/2`, and squaring
-    the ratio:
-
-    >>> symbolic.expression(['a^3', 'b', 'c^-1'])
-    symbolic.Expression(a^3 b c^-1)
-    """
-
-@typing.overload
-def expression_factory(expression: Expression, /) -> Expression:
-    """Create an expression from an expression.
-
-    This mode exists to support algorithms that don't know the type of argument
-    until runtime. If the type is known, it is simpler to use the existing
-    instance.
-
-    Parameters
-    ----------
-    expression : `~symbolic.Expression`
-        An existing instance of this class.
-
-    Examples
-    --------
-    Create an instance from a string:
-
-    >>> this = symbolic.expression('a * b / c')
-
-    Pass the first instance to this class:
-
-    >>> that = symbolic.expression(this)
-
-    Both `this` and `that` represent the same expression...
-
-    >>> this
-    symbolic.expression(a b c^-1)
-    >>> that
-    symbolic.expression(a b c^-1)
-
-    ...because they are the same object.
-
-    >>> that is this
-    True
-    """
-
-def expression_factory(this, **options):
-    if isinstance(this, Expression):
-        if not options:
-            return this
-        raise ValueError(
-            f"Cannot update parsing options on an existing expression"
-        ) from None
-    string = standard(this, joiner='*')
-    terms = _init_terms(string, Parser(**options))
-    return Expression(terms)
-
-
-def standard(
-    this,
-    missing: typing.Optional[str]=None,
-    joiner: str='*',
-) -> str:
-    """Convert `this` to a standard format.
-    
-    Parameters
-    ----------
-    this : string or iterable
-        The object to convert.
-
-    missing : string, optional
-        The value to return if `this` is null.
-
-    joiner : string, default='*'
-        The string token to use when joining parts of an iterable argument.
-
-    See Also
-    --------
-    `~symbolic.Expression`: A class that represents one or more terms joined by
-    symbolic operators and grouped by separator characters. Instances support
-    multiplication and division with strings or other instances, and
-    exponentiation by real numbers. Instantiation automatically calls this
-    function.
-    """
-    if isnull(this):
-        return missing
-    if isinstance(this, str):
-        return this
-    try:
-        iter(this)
-    except TypeError:
-        return str(this)
-    else:
-        return joiner.join(f"({part})" for part in this)
-
-
-def isnull(this: typing.Any) -> bool:
-    """True if `this` is empty but not if it's 0.
-
-    This function allows the calling code to programmatically test for objects
-    that are logically `False` except for numbers equivalent to 0.
-    """
-    if isinstance(this, numbers.Number):
-        return False
-    size = getattr(this, 'size', None)
-    if size is not None:
-        return size == 0
-    try:
-        result = not bool(this)
-    except ValueError:
-        result = all((isnull(i) for i in this))
-    return result
-
-
-def _init_terms(
-    string: str,
-    parser: Parser,
-) -> typing.List[Term]:
-    """Initialize terms for an expression by parsing `string`."""
-    if string is None:
-        return []
-    terms = parser.parse(string)
-    return reduce(terms)
-
-
-def reduce(*groups: typing.Iterable[Term]):
-    """Algebraically reduce terms with equal bases.
-
-    Parameters
-    ----------
-    *groups : tuple of iterables
-        One or more iterables of `~symbolic.Term` instances. If there are
-        multiple groups, this method will combine all terms it finds in the full
-        collection of groups.
-
-    Notes
-    -----
-    This function will sort terms in order of ascending exponent, and
-    alphabetically for equal exponents.
-    """
-    terms = [t for group in groups for t in group]
-    reduced = {}
-    for t in terms:
-        if t.base in reduced:
-            reduced[t.base]['coefficient'] *= t.coefficient
-            reduced[t.base]['exponent'] += t.exponent
-        else:
-            attributes = {
-                'coefficient': t.coefficient,
-                'exponent': t.exponent,
-            }
-            reduced[t.base] = attributes
-    fracs = [
-        fractions.Fraction(v['coefficient'])
-        for v in reduced.values()
-    ]
-    tmp = [
-        term_factory(base=k, exponent=v['exponent'])
-        for k, v in reduced.items()
-        if k != '1' and v['exponent'] != 0
-    ]
-    # Sort: high to low in exponent, followed by alphabetic in base.
-    variables = sorted(
-        sorted(tmp, key=attrgetter('base')),
-        key=attrgetter('exponent'),
-        reverse=True,
-    )
-    c = functools.reduce(lambda x, y: x*y, fracs)
-    constant = [term_factory(coefficient=c)]
-    if not variables:
-        return constant
-    if c == 1:
-        return variables
-    return constant + variables
 
 

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -122,6 +122,32 @@ def test_term_evaluate():
         constant(2)
 
 
+def test_operand_factory():
+    """Test the operand factory function."""
+    cases = {
+        (4, '1', 1): [['4'], [1, '4', 1]],
+        (1, 'a', 1): [['a']],
+        (2, 'a', 1): [['2a'], [1, '2a', 1]],
+        (2, 'a', 3): [['2a^3']],
+        (2**3, 'a', 3): [['(2a)^3'], [1, '2a', 3]],
+        (2**(3/4), 'a', '3/4'): [['(2a)^3/4'], [1, '2a', '3/4']],
+        (4 * 2**3, 'a', 3): [['4(2a)^3'], [4, '2a', 3]],
+        (2, 'a', -1): [['2a^-1']],
+        (1, '2a * b', 3): [['(2a * b)^3']],
+        (3, 'a * b', -2): [['3(a * b)^-2']],
+        (1, 'a / (b * c)', 1): [['a / (b * c)']],
+    }
+    for ref, group in cases.items():
+        from_ref = symbolic.operand(*ref)
+        for args in group:
+            from_args = symbolic.operand(*args)
+            assert from_ref == from_args
+            for part in [from_ref, from_args]:
+                assert part.coefficient == ref[0]
+                assert part.base == ref[1]
+                assert part.exponent == fractions.Fraction(ref[2])
+
+
 def test_create_operand():
     """Test the object representing a part of an expression."""
     cases = {


### PR DESCRIPTION
This PR
- Refactors the package structure
- Adds a convenience function, called `symbolic.operand` in the public API, for directly creating operands via `OperandFactory.create`
- Increments the version number to 0.2.0