### PR TITLE
Add-greek-symbol-support

### DIFF
--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -186,7 +186,7 @@ class Operand(Part):
         )
     """
     base = r"""
-        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
+        [α-ωΑ-ΩςϚϛa-zA-Z#_]+ # one or more accepted non-digit character(s)
         \d*                  # followed by optional digits
     """
 

--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -174,6 +174,22 @@ class Operand(Part):
     `~symbolic.Expression` with `~symbolic.Parser`.
     """
 
+    rational = r""" # Modeled after `fractions._RATIONAL_FORMAT`
+        [-+]?                 # an optional sign, ...
+        (?=\d|\.\d)           # ... only if followed by <digit> or .<digit>
+        \d*                   # and a possibly empty numerator
+        (?:                   # followed by ...
+            (?:/\d+?)         # ... an optional denominator
+        |                     # OR
+            (?:\.\d*)?        # ... an optional fractional part,
+            (?:[eE][-+]?\d+)? #     and an optional exponent
+        )
+    """
+    base = r"""
+        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
+        \d*                  # followed by optional digits
+    """
+
     def __init__(
         self,
         coefficient: numbers.Real=None,
@@ -296,43 +312,27 @@ class OperatorFactory(Factory):
 class OperandFactory(Factory):
     """A factory that produces symbolic operands."""
 
-    rational = r""" # Modeled after `fractions._RATIONAL_FORMAT`
-        [-+]?                 # an optional sign, ...
-        (?=\d|\.\d)           # ... only if followed by <digit> or .<digit>
-        \d*                   # and a possibly empty numerator
-        (?:                   # followed by ...
-            (?:/\d+?)         # ... an optional denominator
-        |                     # OR
-            (?:\.\d*)?        # ... an optional fractional part,
-            (?:[eE][-+]?\d+)? #     and an optional exponent
-        )
-    """
-    base = r"""
-        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
-        \d*               # followed by optional digits
-    """
-
     def __init__(
         self,
         opening: str='(',
         closing: str=')',
         raising: str='^',
     ) -> None:
-        exponent = fr'\{raising}{self.rational}'
+        exponent = fr'\{raising}{Operand.rational}'
         self.patterns = {
             'constant': re.compile(
-                fr'(?P<coefficient>{self.rational})'
+                fr'(?P<coefficient>{Operand.rational})'
                 fr'(?P<exponent>{exponent})?',
                 re.VERBOSE,
             ),
             'variable': re.compile(
-                fr'(?P<coefficient>{self.rational})?'
-                fr'(?P<base>{self.base})'
+                fr'(?P<coefficient>{Operand.rational})?'
+                fr'(?P<base>{Operand.base})'
                 fr'(?P<exponent>{exponent})?',
                 re.VERBOSE,
             ),
             'complex': re.compile(
-                fr'(?P<coefficient>{self.rational})?'
+                fr'(?P<coefficient>{Operand.rational})?'
                 fr'(?P<base>\{opening}.+?\{closing})'
                 fr'(?P<exponent>{exponent})?',
                 re.VERBOSE,
@@ -847,24 +847,7 @@ class Term(Operand):
     combinations.
     """
 
-    # NOTE: Currently redundant with `OperandFactory`.
-
-    rational = r""" # Modeled after `fractions._RATIONAL_FORMAT`
-        [-+]?                 # an optional sign, ...
-        (?=\d|\.\d)           # ... only if followed by <digit> or .<digit>
-        \d*                   # and a possibly empty numerator
-        (?:                   # followed by ...
-            (?:/\d+?)         # ... an optional denominator
-        |                     # OR
-            (?:\.\d*)?        # ... an optional fractional part,
-            (?:[eE][-+]?\d+)? #     and an optional exponent
-        )
-    """
-    base = r"""
-        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
-        \d*               # followed by optional digits
-    """
-    _base_re = re.compile(fr'({rational}|{base})', re.VERBOSE)
+    _base_re = re.compile(fr'({Operand.rational}|{Operand.base})', re.VERBOSE)
 
     @classmethod
     def base_is_valid(cls, base):

--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -185,9 +185,16 @@ class Operand(Part):
             (?:[eE][-+]?\d+)? #     and an optional exponent
         )
     """
-    base = r"""
-        [α-ωΑ-ΩςϚϛa-zA-Z#_]+ # one or more accepted non-digit character(s)
-        \d*                  # followed by optional digits
+    base = r""" # NB: The following `(?: ...)` is arranged to allow additional
+                #     character sets in an organized fashion.
+        (?:                     # one or more accepted ...
+            [α-ωΑ-ΩςϚϛϑϒϕϖϰϱϵϴ] # ... Greek letters
+            |                   # OR
+            [a-zA-Z]            # ... English letters
+            |                   # OR
+            [#_]                # ... symbolic characters
+        )+
+        \d*                          # followed by optional digits
     """
 
     def __init__(

--- a/src/symbolic/_parts.py
+++ b/src/symbolic/_parts.py
@@ -308,8 +308,8 @@ class OperandFactory(Factory):
         )
     """
     base = r"""
-        [a-zA-Z#_]+ # one or more accepted non-digit character(s)
-        \d*         # followed by optional digits
+        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
+        \d*               # followed by optional digits
     """
 
     def __init__(
@@ -861,8 +861,8 @@ class Term(Operand):
         )
     """
     base = r"""
-        [a-zA-Z#_]+ # one or more accepted non-digit character(s)
-        \d*         # followed by optional digits
+        [α-ωΑ-Ωa-zA-Z#_]+ # one or more accepted non-digit character(s)
+        \d*               # followed by optional digits
     """
     _base_re = re.compile(fr'({rational}|{base})', re.VERBOSE)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,59 +22,65 @@ def greek():
     hexidecimal code).
     """
     aslist = [
-        # upper-case standard
-        {'symbol': 'Α', 'hex': r'\x391'},
-        {'symbol': 'Β', 'hex': r'\x392'},
-        {'symbol': 'Γ', 'hex': r'\x393'},
-        {'symbol': 'Δ', 'hex': r'\x394'},
-        {'symbol': 'Ε', 'hex': r'\x395'},
-        {'symbol': 'Ζ', 'hex': r'\x396'},
-        {'symbol': 'Η', 'hex': r'\x397'},
-        {'symbol': 'Θ', 'hex': r'\x398'},
-        {'symbol': 'Ι', 'hex': r'\x399'},
-        {'symbol': 'Κ', 'hex': r'\x39A'},
-        {'symbol': 'Λ', 'hex': r'\x39B'},
-        {'symbol': 'Μ', 'hex': r'\x39C'},
-        {'symbol': 'Ν', 'hex': r'\x39D'},
-        {'symbol': 'Ξ', 'hex': r'\x39E'},
-        {'symbol': 'Ο', 'hex': r'\x39F'},
-        {'symbol': 'Π', 'hex': r'\x3A0'},
-        {'symbol': 'Ρ', 'hex': r'\x3A1'},
-        {'symbol': 'Σ', 'hex': r'\x3A3'},
-        {'symbol': 'Τ', 'hex': r'\x3A4'},
-        {'symbol': 'Υ', 'hex': r'\x3A5'},
-        {'symbol': 'Φ', 'hex': r'\x3A6'},
-        {'symbol': 'Χ', 'hex': r'\x3A7'},
-        {'symbol': 'Ψ', 'hex': r'\x3A8'},
-        {'symbol': 'Ω', 'hex': r'\x3A9'},
-        # lower-case standard
-        {'symbol': 'α', 'hex': r'\x3B1'},
-        {'symbol': 'β', 'hex': r'\x3B2'},
-        {'symbol': 'γ', 'hex': r'\x3B3'},
-        {'symbol': 'δ', 'hex': r'\x3B4'},
-        {'symbol': 'ε', 'hex': r'\x3B5'},
-        {'symbol': 'ζ', 'hex': r'\x3B6'},
-        {'symbol': 'η', 'hex': r'\x3B7'},
-        {'symbol': 'θ', 'hex': r'\x3B8'},
-        {'symbol': 'ι', 'hex': r'\x3B9'},
-        {'symbol': 'κ', 'hex': r'\x3BA'},
-        {'symbol': 'λ', 'hex': r'\x3BB'},
-        {'symbol': 'μ', 'hex': r'\x3BC'},
-        {'symbol': 'ν', 'hex': r'\x3BD'},
-        {'symbol': 'ξ', 'hex': r'\x3BE'},
-        {'symbol': 'ο', 'hex': r'\x3BF'},
-        {'symbol': 'π', 'hex': r'\x3C0'},
-        {'symbol': 'ρ', 'hex': r'\x3C1'},
-        {'symbol': 'σ', 'hex': r'\x3C3'},
-        {'symbol': 'τ', 'hex': r'\x3C4'},
-        {'symbol': 'υ', 'hex': r'\x3C5'},
-        {'symbol': 'φ', 'hex': r'\x3C6'},
-        {'symbol': 'χ', 'hex': r'\x3C7'},
-        {'symbol': 'ψ', 'hex': r'\x3C8'},
-        {'symbol': 'ω', 'hex': r'\x3C9'},
-        # non-standard
+        {'symbol': 'Α', 'hex': r'\x391'}, # Alpha
+        {'symbol': 'Β', 'hex': r'\x392'}, # Beta
+        {'symbol': 'Γ', 'hex': r'\x393'}, # Gamma
+        {'symbol': 'Δ', 'hex': r'\x394'}, # Delta
+        {'symbol': 'Ε', 'hex': r'\x395'}, # Epsilon
+        {'symbol': 'Ζ', 'hex': r'\x396'}, # Zeta
+        {'symbol': 'Η', 'hex': r'\x397'}, # Eta
+        {'symbol': 'Θ', 'hex': r'\x398'}, # Theta
+        {'symbol': 'Ι', 'hex': r'\x399'}, # Iota
+        {'symbol': 'Κ', 'hex': r'\x39A'}, # Kappa
+        {'symbol': 'Λ', 'hex': r'\x39B'}, # Lambda
+        {'symbol': 'Μ', 'hex': r'\x39C'}, # Mu
+        {'symbol': 'Ν', 'hex': r'\x39D'}, # Nu
+        {'symbol': 'Ξ', 'hex': r'\x39E'}, # Xi
+        {'symbol': 'Ο', 'hex': r'\x39F'}, # Omicron
+        {'symbol': 'Π', 'hex': r'\x3A0'}, # Pi
+        {'symbol': 'Ρ', 'hex': r'\x3A1'}, # Rho
+        {'symbol': 'Σ', 'hex': r'\x3A3'}, # Sigma
+        {'symbol': 'Τ', 'hex': r'\x3A4'}, # Tau
+        {'symbol': 'Υ', 'hex': r'\x3A5'}, # Upsilon
+        {'symbol': 'Φ', 'hex': r'\x3A6'}, # Phi
+        {'symbol': 'Χ', 'hex': r'\x3A7'}, # Chi
+        {'symbol': 'Ψ', 'hex': r'\x3A8'}, # Psi
+        {'symbol': 'Ω', 'hex': r'\x3A9'}, # Omega
+        {'symbol': 'Ϛ', 'hex': r'\x3DA'}, # Stigma
+        {'symbol': 'α', 'hex': r'\x3B1'}, # alpha
+        {'symbol': 'β', 'hex': r'\x3B2'}, # beta
+        {'symbol': 'γ', 'hex': r'\x3B3'}, # gamma
+        {'symbol': 'δ', 'hex': r'\x3B4'}, # delta
+        {'symbol': 'ε', 'hex': r'\x3B5'}, # varepsilon
+        {'symbol': 'ζ', 'hex': r'\x3B6'}, # zeta
+        {'symbol': 'η', 'hex': r'\x3B7'}, # eta
+        {'symbol': 'θ', 'hex': r'\x3B8'}, # theta
+        {'symbol': 'ι', 'hex': r'\x3B9'}, # iota
+        {'symbol': 'κ', 'hex': r'\x3BA'}, # kappa
+        {'symbol': 'λ', 'hex': r'\x3BB'}, # lambda
+        {'symbol': 'μ', 'hex': r'\x3BC'}, # mu
+        {'symbol': 'ν', 'hex': r'\x3BD'}, # nu
+        {'symbol': 'ξ', 'hex': r'\x3BE'}, # xi
+        {'symbol': 'ο', 'hex': r'\x3BF'}, # omicron
+        {'symbol': 'π', 'hex': r'\x3C0'}, # pi
+        {'symbol': 'ρ', 'hex': r'\x3C1'}, # rho
         {'symbol': 'ς', 'hex': r'\x3C2'}, # final sigma
-        {'symbol': 'Ϛ', 'hex': r'\x3DA'}, # upper-case stigma
-        {'symbol': 'ϛ', 'hex': r'\x3DB'}, # lower-case stigma
+        {'symbol': 'σ', 'hex': r'\x3C3'}, # sigma
+        {'symbol': 'τ', 'hex': r'\x3C4'}, # tau
+        {'symbol': 'υ', 'hex': r'\x3C5'}, # upsilon
+        {'symbol': 'φ', 'hex': r'\x3C6'}, # varphi
+        {'symbol': 'χ', 'hex': r'\x3C7'}, # chi
+        {'symbol': 'ψ', 'hex': r'\x3C8'}, # psi
+        {'symbol': 'ω', 'hex': r'\x3C9'}, # omega
+        {'symbol': 'ϑ', 'hex': r'\x3D1'}, # vartheta
+        {'symbol': 'ϒ', 'hex': r'\x3D2'}, # (Upsilon variant?)
+        {'symbol': 'ϕ', 'hex': r'\x3D5'}, # phi
+        {'symbol': 'ϖ', 'hex': r'\x3D6'}, # varpi
+        {'symbol': 'ϛ', 'hex': r'\x3DB'}, # stigma
+        {'symbol': 'ϰ', 'hex': r'\x3F0'}, # varkappa
+        {'symbol': 'ϱ', 'hex': r'\x3F1'}, # varrho
+        {'symbol': 'ϵ', 'hex': r'\x3F5'}, # (epsilon variant?)
+        {'symbol': 'ϴ', 'hex': r'\x3F4'}, # (theta variant?)
     ]
     return tuple(aslist)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,5 +72,9 @@ def greek():
         {'symbol': 'χ', 'hex': r'\x3C7'},
         {'symbol': 'ψ', 'hex': r'\x3C8'},
         {'symbol': 'ω', 'hex': r'\x3C9'},
+        # non-standard
+        {'symbol': 'ς', 'hex': r'\x3C2'}, # final sigma
+        {'symbol': 'Ϛ', 'hex': r'\x3DA'}, # upper-case stigma
+        {'symbol': 'ϛ', 'hex': r'\x3DB'}, # lower-case stigma
     ]
     return tuple(aslist)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def pytest_configure(config: pytest.Config):
     """Set pytest configuration values at runtime."""
     config.addinivalue_line(
@@ -9,3 +10,67 @@ def pytest_configure(config: pytest.Config):
         "markers", "expression: tests of symbolic expressions"
     )
 
+
+@pytest.fixture
+def greek():
+    """Greek letters and associated dexadecimal codes.
+    
+    Notes
+    -----
+    The associated unicode value is `U+0HEX`, where HEX is the three-digit
+    hexadecimal value (i.e., the three-digit number following `\\x` in the
+    hexidecimal code).
+    """
+    aslist = [
+        # upper-case standard
+        {'symbol': 'Α', 'hex': r'\x391'},
+        {'symbol': 'Β', 'hex': r'\x392'},
+        {'symbol': 'Γ', 'hex': r'\x393'},
+        {'symbol': 'Δ', 'hex': r'\x394'},
+        {'symbol': 'Ε', 'hex': r'\x395'},
+        {'symbol': 'Ζ', 'hex': r'\x396'},
+        {'symbol': 'Η', 'hex': r'\x397'},
+        {'symbol': 'Θ', 'hex': r'\x398'},
+        {'symbol': 'Ι', 'hex': r'\x399'},
+        {'symbol': 'Κ', 'hex': r'\x39A'},
+        {'symbol': 'Λ', 'hex': r'\x39B'},
+        {'symbol': 'Μ', 'hex': r'\x39C'},
+        {'symbol': 'Ν', 'hex': r'\x39D'},
+        {'symbol': 'Ξ', 'hex': r'\x39E'},
+        {'symbol': 'Ο', 'hex': r'\x39F'},
+        {'symbol': 'Π', 'hex': r'\x3A0'},
+        {'symbol': 'Ρ', 'hex': r'\x3A1'},
+        {'symbol': 'Σ', 'hex': r'\x3A3'},
+        {'symbol': 'Τ', 'hex': r'\x3A4'},
+        {'symbol': 'Υ', 'hex': r'\x3A5'},
+        {'symbol': 'Φ', 'hex': r'\x3A6'},
+        {'symbol': 'Χ', 'hex': r'\x3A7'},
+        {'symbol': 'Ψ', 'hex': r'\x3A8'},
+        {'symbol': 'Ω', 'hex': r'\x3A9'},
+        # lower-case standard
+        {'symbol': 'α', 'hex': r'\x3B1'},
+        {'symbol': 'β', 'hex': r'\x3B2'},
+        {'symbol': 'γ', 'hex': r'\x3B3'},
+        {'symbol': 'δ', 'hex': r'\x3B4'},
+        {'symbol': 'ε', 'hex': r'\x3B5'},
+        {'symbol': 'ζ', 'hex': r'\x3B6'},
+        {'symbol': 'η', 'hex': r'\x3B7'},
+        {'symbol': 'θ', 'hex': r'\x3B8'},
+        {'symbol': 'ι', 'hex': r'\x3B9'},
+        {'symbol': 'κ', 'hex': r'\x3BA'},
+        {'symbol': 'λ', 'hex': r'\x3BB'},
+        {'symbol': 'μ', 'hex': r'\x3BC'},
+        {'symbol': 'ν', 'hex': r'\x3BD'},
+        {'symbol': 'ξ', 'hex': r'\x3BE'},
+        {'symbol': 'ο', 'hex': r'\x3BF'},
+        {'symbol': 'π', 'hex': r'\x3C0'},
+        {'symbol': 'ρ', 'hex': r'\x3C1'},
+        {'symbol': 'σ', 'hex': r'\x3C3'},
+        {'symbol': 'τ', 'hex': r'\x3C4'},
+        {'symbol': 'υ', 'hex': r'\x3C5'},
+        {'symbol': 'φ', 'hex': r'\x3C6'},
+        {'symbol': 'χ', 'hex': r'\x3C7'},
+        {'symbol': 'ψ', 'hex': r'\x3C8'},
+        {'symbol': 'ω', 'hex': r'\x3C9'},
+    ]
+    return tuple(aslist)

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -510,6 +510,14 @@ def test_parser_separators():
     assert equal_terms(expression, expected)
 
 
+def test_parse_greek(greek):
+    """Test the ability to identify Greek characters in terms."""
+    for this in greek:
+        symbol = this['symbol']
+        term = symbolic.term(symbol)
+        assert term.base == symbol
+
+
 @pytest.mark.xfail
 @pytest.mark.expression
 def test_nonstandard_chars():


### PR DESCRIPTION
This PR adds support for Greek symbols in symbolic expressions, and establishes the structure for adding support for additional non-English symbols.